### PR TITLE
indicate python3 is required

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -34,4 +34,4 @@ In order to install the application from the source tarball:
 
   4. Run:
 
-    sudo python setup.py install
+    sudo python3 setup.py install

--- a/build_package
+++ b/build_package
@@ -51,7 +51,7 @@ cp -r debian "$RELEASE_DIR" || err "Copying debian/ into $RELEASE_DIR failed"
 # Build a Debian source package
 pushd .
 cd "$RELEASE_DIR"
-debuild -sa || err "Building Debian package failed"
+debuild -S -sa || err "Building Debian package failed"
 popd >/dev/null
 
 # Cleanup: remove the release dir


### PR DESCRIPTION
makes it more clear that python3 is needed. on ubuntu 14.04, for example, python defaults to 2.7