### PR TITLE
Fix python 3.5 compatibility

### DIFF
--- a/lib/indicator_sound_switcher/indicator.py
+++ b/lib/indicator_sound_switcher/indicator.py
@@ -1097,4 +1097,4 @@ class SoundSwitcherIndicator(GObject.GObject):
         :return: True if the given index corresponds to a virtual card
         """
         # Assume all indexes bigger than 2e9 are virtual cards
-        return card_index > 2000_000_000
+        return card_index > 2000000000


### PR DESCRIPTION
This line is the only line that breaks 3.5 compatibility, which is a pitty for users like me who run debian and don't have a support 3.6 version.

See: https://www.python.org/dev/peps/pep-0515/