### PR TITLE
Add support for using Ayatana AppIndicators

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Depends:
  ${python3:Depends},
  python3-gi,
  gir1.2-gtk-3.0 (>= 3.20),
- gir1.2-appindicator3-0.1,
+ gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1,
  libpulse0
 Description: Sound input/output selector indicator
  A simple yet usable application indicator for Ubuntu/Unity. It allows for

--- a/lib/indicator_sound_switcher/indicator.py
+++ b/lib/indicator_sound_switcher/indicator.py
@@ -2,12 +2,17 @@ import os.path
 import logging
 import time
 
-from gi import require_version
-require_version('Gtk', '3.0')
+import gi
+
+gi.require_version('Gtk', '3.0')
 from gi.repository import GObject, Gtk, GLib
 
-require_version('AppIndicator3', '0.1')
-from gi.repository import AppIndicator3 as AppIndicator
+try:
+    gi.require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator
+except ValueError:
+    gi.require_version('AppIndicator3', '0.1')
+    from gi.repository import AppIndicator3 as AppIndicator
 
 from .lib_pulseaudio import *
 from .card import CardProfile, Card


### PR DESCRIPTION
Switch to Ayatana AppIndicators by default, and fall back to the
existing (pre-fork) AppIndicators if not found. See:
- https://ayatanaindicators.github.io/
- https://lists.debian.org/debian-devel/2018/03/msg00506.html
...for more information.