### PR TITLE
Fix autostart after multiple snap updates

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -4,9 +4,7 @@
 
 AUTOSTART="$SNAP_USER_DATA/.config/autostart/"
 
-if [ ! -d "$AUTOSTART" ]; then
-    mkdir -p "$AUTOSTART"
-fi
+mkdir -p "$AUTOSTART"
 
 ln -sfnt "$AUTOSTART" "$SNAP/share/applications/indicator-sound-switcher.desktop"
 

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -2,12 +2,12 @@
 
 # Make sure a link to desktop launcher is added to the autostart dir
 
-AUTOSTART="$SNAP_USER_DATA/.config/autostart"
+AUTOSTART="$SNAP_USER_DATA/.config/autostart/"
 
 if [ ! -d "$AUTOSTART" ]; then
     mkdir -p "$AUTOSTART"
 fi
 
-ln -sfnt "$AUTOSTART/" "$SNAP/share/applications/indicator-sound-switcher.desktop"
+ln -sfnt "$AUTOSTART" "$SNAP/share/applications/indicator-sound-switcher.desktop"
 
 exec "$@"

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 
 # Make sure a link to desktop launcher is added to the autostart dir
-autostart_dir="$SNAP_USER_DATA/.config/autostart"
-if [ ! -d "$autostart_dir" ]; then
-	mkdir -p "$autostart_dir"
-	ln -sfnt "$autostart_dir/" "$SNAP/share/applications/indicator-sound-switcher.desktop"
+
+AUTOSTART="$SNAP_USER_DATA/.config/autostart"
+
+if [ ! -d "$AUTOSTART" ]; then
+    mkdir -p "$AUTOSTART"
 fi
+
+ln -sfnt "$AUTOSTART/" "$SNAP/share/applications/indicator-sound-switcher.desktop"
 
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ description: |
 
 icon: icons/indicator-sound-switcher.svg
 license: GPL-3.0
+grade: stable
 confinement: strict
 
 apps:
@@ -29,7 +30,6 @@ apps:
 parts:
   indicator-sound-switcher:
     plugin: python
-    python-version: python3
     source: .
     build-packages:
       - gettext
@@ -46,8 +46,8 @@ parts:
 
       # Use version from setup.py
       version="$(sed -ne 's/\s*APP_VERSION\s*=\s*\x27\([^\x27]\+\)\x27.*/\1/p' setup.py)"
+      
       snapcraftctl set-version "$version"
-      snapcraftctl set-grade "stable"
 
       # Fix icon path in the .desktop
       sed -i -E 's!^Icon=.*!Icon=/usr/share/icons/hicolor/scalable/status/indicator-sound-switcher.svg!' indicator-sound-switcher.desktop
@@ -59,5 +59,5 @@ parts:
       icons: usr/share/icons/hicolor/scalable/status
       snap/local/launch.sh: bin/
     stage:
-      - usr/
-      - bin/
+      - usr/*
+      - bin/*


### PR DESCRIPTION
Resolves #128.

Исправлена проблема, суть которой в следующем: символическая ссылка на .desktop файл создаётся в $SNAP_USER_DATA/.config/autostart/ только во время первого запуска после установки и не изменяется после обновлений snap пакета. Snapd хранит только две ревизии $SNAP_USER_DATA: текущую и предыдущую. К примеру мы установили пакет с ревизией 90. В /home/user/snap/indicator-sound-switcher/ создаётся директория 90 и $SNAP_USER_DATA указывает на эту директорию. После первого запуска программы в $SNAP_USER_DATA/.config/autostart/ создаётся символическая ссылка на /snap/indicator-sound-switcher/90/share/applications/indicator-sound-switcher.desktop. Далее мы обновляем snap пакет на ревизию 91, но символическая ссылка $SNAP_USER_DATA/.config/autostart/indicator-sound-switcher.desktop будет указывать на .desktop файл из предыдущей ревизии - /snap/indicator-sound-switcher/90/share/applications/indicator-sound-switcher.desktop. Пока что всё нормально. Но при следующем обновлении на ревизию 92, директория с ревизией 90 удаляется(/snap/indicator-sound-switcher/90/) и теперь наша ссылка указывает на несуществующую директорию и как следствие автозапуск перестаёт работать

Также внёс небольшие изменения в snapcraft.yaml. Во-первых при сборке на современных версиях snapcraft ругается на то, что в секции stage указаны директории. А во-вторых ругается на директиву python-version, которая судя по всему становится deprecated